### PR TITLE
Patch/release 0.1.4 alpha

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -6,9 +6,9 @@
         "storybook-docs": "storybook dev --docs"
     },
     "devDependencies": {
-        "@niagads/common": "0.1.3-alpha.0",
-        "@niagads/table": "0.1.3-alpha.0",
-        "@niagads/ui": "0.1.3-alpha.0",
+        "@niagads/common": "0.1.4-alpha.0",
+        "@niagads/table": "0.1.4-alpha.0",
+        "@niagads/ui": "0.1.4-alpha.0",
         "@storybook/addon-controls": "^8.6.10",
         "@storybook/addon-essentials": "^8.2.8",
         "@storybook/addon-interactions": "^8.2.8",

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
     "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-    "version": "0.1.3-alpha.0"
+    "version": "0.1.4-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20378,6 +20378,7 @@
                 "rollup-plugin-dts": "^6.1.1",
                 "rollup-plugin-peer-deps-external": "^2.2.4",
                 "rollup-plugin-postcss": "^4.0.2",
+                "style-inject": "^0.3.0",
                 "tailwindcss": "^4.0"
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
         "apps/storybook": {
             "name": "niagads-viz-js.storybook",
             "devDependencies": {
-                "@niagads/common": "0.1.3-alpha.0",
-                "@niagads/table": "0.1.3-alpha.0",
-                "@niagads/ui": "0.1.3-alpha.0",
+                "@niagads/common": "0.1.4-alpha.0",
+                "@niagads/table": "0.1.4-alpha.0",
+                "@niagads/ui": "0.1.4-alpha.0",
                 "@storybook/addon-controls": "^8.6.10",
                 "@storybook/addon-essentials": "^8.2.8",
                 "@storybook/addon-interactions": "^8.2.8",
@@ -20211,7 +20211,7 @@
         },
         "packages/Common": {
             "name": "@niagads/common",
-            "version": "0.1.3-alpha.0",
+            "version": "0.1.4-alpha.0",
             "dependencies": {
                 "react-error-boundary": "^4.0.13"
             },
@@ -20269,11 +20269,11 @@
         },
         "packages/Table": {
             "name": "@niagads/table",
-            "version": "0.1.3-alpha.0",
+            "version": "0.1.4-alpha.0",
             "dependencies": {
                 "@heroicons/react": "^2.2.0",
-                "@niagads/common": "^0.1.3-alpha.0",
-                "@niagads/ui": "^0.1.3-alpha.0",
+                "@niagads/common": "^0.1.4-alpha.0",
+                "@niagads/ui": "^0.1.4-alpha.0",
                 "@tanstack/react-table": "^8.11.8",
                 "export-from-json": "github:NIAGADS/export-from-json#niagads",
                 "lodash.countby": "^4.6.0",
@@ -20360,11 +20360,11 @@
         },
         "packages/UI": {
             "name": "@niagads/ui",
-            "version": "0.1.3-alpha.0",
+            "version": "0.1.4-alpha.0",
             "license": "GPL-3.0-only",
             "dependencies": {
                 "@heroicons/react": "^2.2.0",
-                "@niagads/common": "^0.1.3-alpha.0",
+                "@niagads/common": "^0.1.4-alpha.0",
                 "react-tooltip": "^5.28.0"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20365,7 +20365,8 @@
             "dependencies": {
                 "@heroicons/react": "^2.2.0",
                 "@niagads/common": "^0.1.4-alpha.0",
-                "react-tooltip": "^5.28.0"
+                "react-tooltip": "^5.28.0",
+                "style-inject": "^0.3.0"
             },
             "devDependencies": {
                 "@rollup/plugin-commonjs": "^28.0.2",
@@ -20378,7 +20379,6 @@
                 "rollup-plugin-dts": "^6.1.1",
                 "rollup-plugin-peer-deps-external": "^2.2.4",
                 "rollup-plugin-postcss": "^4.0.2",
-                "style-inject": "^0.3.0",
                 "tailwindcss": "^4.0"
             }
         }

--- a/packages/Common/package.json
+++ b/packages/Common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@niagads/common",
-    "version": "0.1.3-alpha.0",
+    "version": "0.1.4-alpha.0",
     "scripts": {
         "build": "rollup -c"
     },

--- a/packages/Table/package.json
+++ b/packages/Table/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@niagads/table",
-    "version": "0.1.3-alpha.0",
+    "version": "0.1.4-alpha.0",
     "scripts": {
         "build": "rollup -c"
     },
@@ -37,8 +37,8 @@
     },
     "dependencies": {
         "@heroicons/react": "^2.2.0",
-        "@niagads/common": "^0.1.3-alpha.0",
-        "@niagads/ui": "^0.1.3-alpha.0",
+        "@niagads/common": "^0.1.4-alpha.0",
+        "@niagads/ui": "^0.1.4-alpha.0",
         "@tanstack/react-table": "^8.11.8",
         "export-from-json": "github:NIAGADS/export-from-json#niagads",
         "lodash.countby": "^4.6.0",

--- a/packages/UI/package.json
+++ b/packages/UI/package.json
@@ -22,7 +22,8 @@
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "tailwindcss": "^4.0"
+        "tailwindcss": "^4.0",
+        "style-inject": "^0.3.0"
     },
     "dependencies": {
         "@heroicons/react": "^2.2.0",

--- a/packages/UI/package.json
+++ b/packages/UI/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@niagads/ui",
-    "version": "0.1.3-alpha.0",
+    "version": "0.1.4-alpha.0",
     "description": "NIAGADS Common UI React Component Library",
     "repository": {
         "type": "git",
@@ -22,12 +22,12 @@
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "tailwindcss": "^4.0",
-        "style-inject": "^0.3.0"
+        "style-inject": "^0.3.0",
+        "tailwindcss": "^4.0"
     },
     "dependencies": {
         "@heroicons/react": "^2.2.0",
-        "@niagads/common": "^0.1.3-alpha.0",
+        "@niagads/common": "^0.1.4-alpha.0",
         "react-tooltip": "^5.28.0"
     },
     "main": "dist/index.js",

--- a/packages/UI/package.json
+++ b/packages/UI/package.json
@@ -22,13 +22,13 @@
         "rollup-plugin-dts": "^6.1.1",
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "style-inject": "^0.3.0",
         "tailwindcss": "^4.0"
     },
     "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@niagads/common": "^0.1.4-alpha.0",
-        "react-tooltip": "^5.28.0"
+        "react-tooltip": "^5.28.0",
+        "style-inject": "^0.3.0"
     },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
style-inject missing from UI package.json.  Patch NPM release incorrectly makes it a dev dependency and doesn't fix the problem.  Committed correction for next patch as problem can be temporarily solved by adding style-inject package to the importing project.