### PR TITLE
fix runtime bugs

### DIFF
--- a/apps/genomicsdb/TODOS.md
+++ b/apps/genomicsdb/TODOS.md
@@ -8,8 +8,6 @@
 
 * how to handle fonts UI/application
 
-* predicted consequece coloring in report overviews and tables: <https://useast.ensembl.org/info/genome/variation/prediction/predicted_data.html>
-
 ## Zile - in order of priority
 
 * Record Table in tabbed-sections are not fitting to enclosing div, no scrolling on x-overflow, instead div (Card?) is growing.  

--- a/apps/genomicsdb/app/record/[type]/[id]/annotation/[...subpath]/route.ts
+++ b/apps/genomicsdb/app/record/[type]/[id]/annotation/[...subpath]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { _fetch, fetchRecordAnnotationTable } from "@/lib/route-handlers";
+
+import { fetchRecordAnnotationTable } from "@/lib/route-handlers";
 
 // for client-side fetching from the API w/ioredis caching
 
@@ -7,12 +8,12 @@ import { _fetch, fetchRecordAnnotationTable } from "@/lib/route-handlers";
 export async function GET(req: NextRequest) {
     // Get the full pathname from the request
     // remove the /annotation subpath
-    // add api prefix if missing
+
     let endpoint = req.nextUrl.pathname;
     endpoint = endpoint.replace("/annotation", "");
-    if (!endpoint.startsWith("/api")) {
-        endpoint = `/api${endpoint}`;
-    }
+
+    // add api prefix
+    endpoint = `/api${endpoint}`;
 
     // Append query parameters if present
     const search = req.nextUrl.search;

--- a/apps/genomicsdb/app/record/sections.tsx
+++ b/apps/genomicsdb/app/record/sections.tsx
@@ -88,6 +88,8 @@ const __SPAN_RECORD_SECTIONS: AnchoredPageSection[] = [
 ];
 
 const __GENE_RECORD_SECTIONS: AnchoredPageSection[] = [
+    GWAS_ASSOC_SECTION,
+    CURATED_ASSOC_SECTION,
     //{ id: "link-outs", label: "Link outs", description: "", icon: "link", tables: [] },
     {
         id: "predicted-function",
@@ -123,7 +125,6 @@ const __VARIANT_RECORD_SECTIONS: AnchoredPageSection[] = [
     { id: "overview", label: "Overview", icon: "home" },
     GWAS_ASSOC_SECTION,
     CURATED_ASSOC_SECTION,
-    //{ id: "link-outs", label: "Link outs", description: "", icon: "link", tables: [] },
     {
         id: "predicted-consequences",
         label: "Predicted Consequences",

--- a/apps/genomicsdb/lib/reference.ts
+++ b/apps/genomicsdb/lib/reference.ts
@@ -52,4 +52,5 @@ export const ExternalUrls = {
     HGNC_URL: "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/",
     EFO_TRAIT_URL: "http://www.ebi.ac.uk/efo/",
     ALPHAFOLDDB_PROTEIN_URL: "https://alphafold.ebi.ac.uk/entry/",
+    GNOMAD_URL: "https://gnomad.broadinstitute.org/",
 };

--- a/apps/genomicsdb/lib/route-handlers.ts
+++ b/apps/genomicsdb/lib/route-handlers.ts
@@ -57,6 +57,9 @@ export async function fetchRecordAssocations(
 }
 
 export async function _fetch(endpoint: string, content: ResponseContent = "full", dataOnly: boolean = false) {
+    if (!endpoint.startsWith("/api/")) {
+        throw Error("Runtime Error: _fetch wrapper is for querying /api endpoints only.");
+    }
     let query = endpoint;
     let namespace: string = "";
     if (endpoint.includes("/service/")) {


### PR DESCRIPTION
* added error handler to _fetch that throws an error if the endpoint does not start with /api
* removed empty path in app/record/gene/annotation that was conflicting with /app/record/[type]/[id]/annotation to fix table loads
* added association tables back into gene page (copy/paste error)
* couple of minor changes to variant record from branch original purpose